### PR TITLE
Bump Alpine base image to 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.15
 MAINTAINER barwell
 
 RUN apk --update add \


### PR DESCRIPTION
I noticed that the base image in the Dockerfile is Alpine version 3.10, which [went end of life on 2021-05-01](https://alpinelinux.org/releases/). This PR bumps it to the latest stable version - v3.15